### PR TITLE
add mode-local comment syntax and remove faust-comment-dwim

### DIFF
--- a/faust-mode.el
+++ b/faust-mode.el
@@ -37,7 +37,6 @@
 ;; Colorize arguments (numbers)
 ;; Colorize [] metadata in string?
 ;; Run Shell faust w/ custom defaults
-;; *** Get rid of the No comment syntax defined warning
 
 
 ;; ROADMAP
@@ -96,17 +95,9 @@
   ;; code for syntax highlighting
   (setq font-lock-defaults '((faust-font-lock-keywords)))
 
-  ;; modify the keymap
-  (define-key faust-mode-map [remap comment-dwim] 'faust-comment-dwim))
-
-;; comment dwin support
-(defun faust-comment-dwim (arg)
-"Comment or uncomment current line or region in a smart way.
-For detail, see `comment-dwim'."
-   (interactive "*P")
-   (require 'newcomment)
-   (let ((deactivate-mark nil) (comment-start "//") (comment-end ""))
-     (comment-dwim arg)))
+  ;; set mode-local comment syntax
+  (set (make-local-variable 'comment-start) "// ")
+  (set (make-local-variable 'comment-end) ""))
 
 (modify-syntax-entry ?/  ". 124b" faust-mode-syntax-table)
 (modify-syntax-entry ?*  ". 23" faust-mode-syntax-table)


### PR DESCRIPTION
This should fix the issue with the comment syntax being undefined. The `faust-comment-dwim' function is then unnecessary so I've removed it.
